### PR TITLE
Enable cluster observability

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -90,6 +90,10 @@ resource "aws_autoscaling_group" "web-asg" {
     version = "$Default"
   }
 
+  instance_refresh {
+    strategy = "Rolling"
+  }
+
   lifecycle {
     ignore_changes = [desired_capacity]
   }

--- a/main.tf
+++ b/main.tf
@@ -193,6 +193,14 @@ resource "aws_ecs_task_definition" "web-task-definition" {
           protocol      = "tcp"
         }
       ]
+      logConfiguration = {
+        logDriver = "awslogs",
+        options   = {
+          "awslogs-group"         = aws_cloudwatch_log_group.web-log-group.name,
+          "awslogs-region"        = var.region,
+          "awslogs-stream-prefix" = "web"
+        }
+      }
     }
   ])
 }

--- a/main.tf
+++ b/main.tf
@@ -74,6 +74,17 @@ resource "aws_autoscaling_group" "web-asg" {
   protect_from_scale_in = true
   vpc_zone_identifier = var.web_subnets
 
+  enabled_metrics = [
+    "GroupMinSize",
+    "GroupMaxSize",
+    "GroupDesiredCapacity",
+    "GroupInServiceInstances",
+    "GroupPendingInstances",
+    "GroupStandbyInstances",
+    "GroupTerminatingInstances",
+    "GroupTotalInstances"
+  ]
+
   launch_template {
     id      = aws_launch_template.capacity-temp.id
     version = "$Default"

--- a/main.tf
+++ b/main.tf
@@ -152,13 +152,8 @@ resource "aws_lb_target_group" "web-tg" {
   port     = local.http_port
   protocol = "HTTP"
   vpc_id   = var.vpc_id
+  depends_on = [aws_alb.web-lb]
 }
-
-# resource "aws_autoscaling_attachment" "web-atg-tg-att" {
-#   autoscaling_group_name = aws_autoscaling_group.web-asg.id
-#   lb_target_group_arn    = aws_lb_target_group.web-tg.arn
-# }
-
 
 # ECS cluster.
 resource "aws_ecs_cluster" "web-cluster" {

--- a/main.tf
+++ b/main.tf
@@ -198,7 +198,7 @@ resource "aws_ecs_task_definition" "web-task-definition" {
 }
 
 # Cloudwatch log group
-resource "aws_cloudwatch_log_group" "log_group" {
+resource "aws_cloudwatch_log_group" "web-log-group" {
   name              = "/${var.prefix}/ecs/${local.container_name}"
   retention_in_days = 1
 }

--- a/main.tf
+++ b/main.tf
@@ -197,6 +197,12 @@ resource "aws_ecs_task_definition" "web-task-definition" {
   ])
 }
 
+# Cloudwatch log group
+resource "aws_cloudwatch_log_group" "log_group" {
+  name              = "/${var.prefix}/ecs/${local.container_name}"
+  retention_in_days = 1
+}
+
 #ECS service
 resource "aws_ecs_service" "web-service" {
   name                               = "${var.prefix}_ECSWEB_service"

--- a/variable.tf
+++ b/variable.tf
@@ -11,3 +11,4 @@ variable "vpc_id" {}
 variable "iam_instance_profile_arn" {}
 variable "task_exec_role" {}
 variable "container_image" {}
+variable "region" {}


### PR DESCRIPTION
## Context 

This PR enables the monitoring of container Instance metrics into a cloud watch log group.